### PR TITLE
when $instance->ipaddress is undef, try ssh with privateIpAddress

### DIFF
--- a/lib/Yogafire/CommandClass/SSH.pm
+++ b/lib/Yogafire/CommandClass/SSH.pm
@@ -53,7 +53,7 @@ sub build_raw_ssh_command {
         my $host = $instance->privateIpAddress;
         @cmd = ('ssh', '-p', $self->port, '-i', $self->identity_file, '-l', $self->user, '-oProxyCommand="', $self->build_proxy_command(), '"', $host);
     } else {
-        my $host = $instance->ipAddress;
+        my $host = $instance->ipAddress || $instance->privateIpAddress;
         @cmd = ('ssh', '-p', $self->port, '-i', $self->identity_file, '-l', $self->user, $host);
     }
     return join(' ', @cmd);


### PR DESCRIPTION
Hi, 
I want to use yogafire ssh command in internal network connected to VPC via VPN.
So, when ssh, try to use `$instance->privateIpAddress` if `$instance->ipAddres` was undef. 

Thanks.
